### PR TITLE
Postgresql CURRENT_TIMESTAMP converted at UTC timezone #393

### DIFF
--- a/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/DbImplPg.java
+++ b/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/DbImplPg.java
@@ -19,7 +19,8 @@ public class DbImplPg extends DbAdapter
                 .replace(" REAL", " DOUBLE PRECISION").replace("UNIX_MILLIS()", "extract('epoch' from current_timestamp)*1000")
                 .replace("IN(UNNEST(?))", "=ANY(?)").replace("CURRENT_TIMESTAMP - 1 MINUTE", "NOW() - INTERVAL '1 MINUTES'")
                 .replace("CURRENT_TIMESTAMP - ? SECOND", "(NOW() - (? || ' SECONDS')::interval)").replace("FROM (VALUES(0))", "")
-                .replace("__T__", this.tablePrefix);
+                .replace("__T__", this.tablePrefix)
+                .replace("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'");
     }
 
     @Override


### PR DESCRIPTION
Issue occurs when the DB is in a different Time Zone than UTC.

JQM uses postgres timestamp data field without time zone, stored as UTC timestamp.
Fix is to convert explicitly the CURRENT_TIMESTAMP to UTC, to be properly handled without its time zone. 

Related issue :
https://github.com/enioka-Haute-Couture/jqm/issues/400
https://github.com/enioka-Haute-Couture/jqm/commit/ac8fd9b77a8879e13ca5038f5c8e1d33c10cf3d9