### PR TITLE
Fix liquibase error

### DIFF
--- a/jqm-all/jqm-dbadapter/jqm-dbadapter-mysql8/src/main/java/com/enioka/jqm/jdbc/impl/mysql8/DbImplMySql8.java
+++ b/jqm-all/jqm-dbadapter/jqm-dbadapter-mysql8/src/main/java/com/enioka/jqm/jdbc/impl/mysql8/DbImplMySql8.java
@@ -39,14 +39,14 @@ public class DbImplMySql8 extends DbAdapter
         {
             return "";
         }
-        return sql.replace("MEMORY TABLE", "TABLE").replace("ID BIGINT NOT NULL", "ID BIGINT NOT NULL AUTO_INCREMENT")
-                .replace("JQM_PK.nextval", "NULL").replace(" DOUBLE", " DOUBLE PRECISION")
+        return sql.replace("MEMORY TABLE", "TABLE")
+                .replace("JQM_PK.nextval", "NULL")
                 .replace("UNIX_MILLIS()", "ROUND(UNIX_TIMESTAMP(NOW(4)) * 1000)").replace("IN(UNNEST(?))", "IN(?)")
                 .replace("CURRENT_TIMESTAMP - 1 MINUTE", "(UNIX_TIMESTAMP() - 60)")
                 .replace("CURRENT_TIMESTAMP - ? SECOND", "(UTC_TIMESTAMP() - INTERVAL ? SECOND)").replace("FROM (VALUES(0))", "FROM DUAL")
-                .replace("DNS||':'||PORT", "CONCAT(DNS, ':', PORT)").replace(" TIMESTAMP ", " DATETIME(3) ")
+                .replace("DNS||':'||PORT", "CONCAT(DNS, ':', PORT)")
                 .replace("CURRENT_TIMESTAMP", "FFFFFFFFFFFFFFFFF@@@@").replace("FFFFFFFFFFFFFFFFF@@@@", "UTC_TIMESTAMP(3)")
-                .replace("DATETIME(3) NOT NULL", "DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)").replace("__T__", this.tablePrefix);
+                .replace("__T__", this.tablePrefix);
     }
 
     @Override

--- a/jqm-all/jqm-dbadapter/jqm-dbadapter-oracle/src/main/java/com/enioka/jqm/jdbc/impl/oracle/DbImplOracle.java
+++ b/jqm-all/jqm-dbadapter/jqm-dbadapter-oracle/src/main/java/com/enioka/jqm/jdbc/impl/oracle/DbImplOracle.java
@@ -45,11 +45,11 @@ public class DbImplOracle extends DbAdapter
     @Override
     public String adaptSql(String sql)
     {
-        return sql.replace("MEMORY TABLE", "TABLE").replace(" INTEGER", " NUMBER(10, 0)").replace(" DOUBLE", " DOUBLE PRECISION")
+        return sql.replace("MEMORY TABLE", "TABLE")
                 .replace("UNIX_MILLIS()", "JQM_PK.currval").replace("IN(UNNEST(?))", "IN(?)")
                 .replace("CURRENT_TIMESTAMP - 1 MINUTE", "(CURRENT_TIMESTAMP - 1/1440)")
                 .replace("CURRENT_TIMESTAMP - ? SECOND", "(CURRENT_TIMESTAMP - ?/86400)").replace("FROM (VALUES(0))", "FROM DUAL")
-                .replace("BOOLEAN", "NUMBER(1)").replace("true", "1").replace("false", "0").replace("__T__", this.tablePrefix)
+                .replace("true", "1").replace("false", "0").replace("__T__", this.tablePrefix)
                 .replace("CURRENT_TIMESTAMP", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)");
     }
 

--- a/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/JndiTest.java
+++ b/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/JndiTest.java
@@ -172,7 +172,7 @@ public class JndiTest extends JqmBaseTest
     @Test
     public void testJndiJdbcPool() throws Exception
     {
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
         cnx.runUpdate("jndiprm_update_value_by_key", "true", "jmxEnabled");
         cnx.commit();
@@ -194,7 +194,7 @@ public class JndiTest extends JqmBaseTest
     public void testJndiJdbcPoolLeakWithoutHunter() throws Exception
     {
         // Sanity check - our test DOES leak connections
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
         cnx.runUpdate("jndiprm_update_value_by_key", "true", "jmxEnabled");
         cnx.commit();
@@ -222,7 +222,7 @@ public class JndiTest extends JqmBaseTest
         // Create a connection with our custom interceptor
         Map<String, String> prms = new HashMap<>(1);
         prms.put("jdbcInterceptors", "com.enioka.jqm.providers.PayloadInterceptor");
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", prms);
 
         cnx.runUpdate("jndiprm_update_value_by_key", "true", "jmxEnabled");

--- a/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/MiscTest.java
+++ b/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/MiscTest.java
@@ -110,9 +110,9 @@ public class MiscTest extends JqmBaseTest
         // tests on other databases
         AssumeHsqldb();
 
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
-        CreationTools.createDatabaseProp("jdbc/jqm2", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost/testdbengine", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/jqm2", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost/testdbengine", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
 
         CreationTools.createJobDef(null, true, "App", null, "jqm-tests/jqm-test-em/target/test.jar", TestHelpers.qVip, 42, "jqm-test-em",
@@ -128,7 +128,7 @@ public class MiscTest extends JqmBaseTest
     @Test
     public void testJobWithPersistenceUnitAndEngineApi() throws Exception
     {
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
         JqmSimpleTest.create(cnx, "pyl.CompatHibApi", "jqm-test-pyl-hibapi").expectOk(2).run(this);
     }
@@ -136,9 +136,9 @@ public class MiscTest extends JqmBaseTest
     @Test
     public void testJobWithPersistenceUnitAndEngineApiAndXmlParams() throws Exception
     {
-        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/test", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdbmarsu", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
-        CreationTools.createDatabaseProp("jdbc/jqm2", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost/testdbengine", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/jqm2", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost/testdbengine", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
         cnx.commit();
 

--- a/jqm-all/jqm-model-updater/jqm-model-updater-liquibase/src/main/resources/liquibase-xml/changelogs/changelog-3.0.0.xml
+++ b/jqm-all/jqm-model-updater/jqm-model-updater-liquibase/src/main/resources/liquibase-xml/changelogs/changelog-3.0.0.xml
@@ -28,7 +28,7 @@
             </column>
             <column name="JMX_REGISTRY_PORT" type="INTEGER" />
             <column name="JMX_SERVER_PORT" type="INTEGER" />
-            <column name="LAST_SEEN_ALIVE" type="TIMESTAMP" />
+            <column name="LAST_SEEN_ALIVE" type="TIMESTAMP(3)" />
             <column name="LOAD_API_ADMIN" type="BOOLEAN" />
             <column name="LOAD_API_CLIENT" type="BOOLEAN" />
             <column name="LOAD_API_SIMPLE" type="BOOLEAN" />
@@ -62,7 +62,7 @@
                     nullable="false" />
             </column>
             <column name="ENABLED" type="BOOLEAN" />
-            <column name="LAST_MODIFIED" type="TIMESTAMP" />
+            <column name="LAST_MODIFIED" type="TIMESTAMP(3)" />
             <column name="MAX_THREAD" type="INTEGER">
                 <constraints nullable="false" />
             </column>
@@ -264,7 +264,7 @@
             <column name="PRIORITY" type="INTEGER">
                 <constraints nullable="true" />
             </column>
-            <column name="LAST_UPDATED" type="TIMESTAMP">
+            <column name="LAST_UPDATED" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
         </createTable>
@@ -307,16 +307,16 @@
                 <constraints nullable="true" />
             </column>
 
-            <column name="DATE_ENQUEUE" type="TIMESTAMP">
+            <column name="DATE_ENQUEUE" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
-            <column name="DATE_ATTRIBUTION" type="TIMESTAMP">
+            <column name="DATE_ATTRIBUTION" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
-            <column name="DATE_START" type="TIMESTAMP">
+            <column name="DATE_START" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
-            <column name="DATE_NOT_BEFORE" type="TIMESTAMP">
+            <column name="DATE_NOT_BEFORE" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
 
@@ -409,19 +409,19 @@
                 <constraints nullable="true" />
             </column>
 
-            <column name="DATE_ENQUEUE" type="TIMESTAMP">
+            <column name="DATE_ENQUEUE" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
-            <column name="DATE_ATTRIBUTION" type="TIMESTAMP">
+            <column name="DATE_ATTRIBUTION" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
-            <column name="DATE_START" type="TIMESTAMP">
+            <column name="DATE_START" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
-            <column name="DATE_NOT_BEFORE" type="TIMESTAMP">
+            <column name="DATE_NOT_BEFORE" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
-            <column name="DATE_END" type="TIMESTAMP">
+            <column name="DATE_END" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
 
@@ -601,7 +601,7 @@
             <column name="FACTORY" type="VARCHAR(1000)">
                 <constraints nullable="false" />
             </column>
-            <column name="LAST_MODIFIED" type="TIMESTAMP">
+            <column name="LAST_MODIFIED" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
             <column name="NAME" type="VARCHAR(100)">
@@ -627,7 +627,7 @@
             <column name="KEYNAME" type="VARCHAR(50)">
                 <constraints nullable="false" />
             </column>
-            <column name="LAST_MODIFIED" type="TIMESTAMP">
+            <column name="LAST_MODIFIED" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
             <column name="VALUE" type="VARCHAR(1000)">
@@ -693,13 +693,13 @@
             <column name="ID" type="BIGINT">
                 <constraints primaryKey="true" primaryKeyName="PK_RUSER" nullable="false" />
             </column>
-            <column name="CREATION_DATE" type="TIMESTAMP">
+            <column name="CREATION_DATE" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
             <column name="EMAIL" type="VARCHAR(255)">
                 <constraints nullable="true" />
             </column>
-            <column name="EXPIRATION_DATE" type="TIMESTAMP">
+            <column name="EXPIRATION_DATE" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
             <column name="FREETEXT" type="VARCHAR(255)">
@@ -711,7 +711,7 @@
             <column name="INTERNAL" type="BOOLEAN">
                 <constraints nullable="true" />
             </column>
-            <column name="LAST_MODIFIED" type="TIMESTAMP">
+            <column name="LAST_MODIFIED" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
             <column name="LOCKED" type="BOOLEAN">
@@ -757,7 +757,7 @@
                 <constraints unique="true" uniqueConstraintName="UK_GLOBAL_PARAMETER_1"
                     nullable="false" />
             </column>
-            <column name="LAST_MODIFIED" type="TIMESTAMP">
+            <column name="LAST_MODIFIED" type="TIMESTAMP(3)">
                 <constraints nullable="false" />
             </column>
             <column name="VALUE" type="VARCHAR(1000)">
@@ -775,10 +775,14 @@
             <column name="NODE" type="BIGINT">
                 <constraints nullable="true" />
             </column>
-            <column name="LATEST_CONTACT" type="TIMESTAMP">
+            <column name="LATEST_CONTACT" type="TIMESTAMP(3)">
                 <constraints nullable="true" />
             </column>
         </createTable>
+
+        <modifySql dbms="mariadb,mysql">
+            <replace  replace="ID BIGINT NOT NULL"  with="ID BIGINT NOT NULL AUTO_INCREMENT"/>
+        </modifySql>
     </changeSet>
 
 </databaseChangeLog>

--- a/jqm-all/jqm-test-helpers/src/main/java/com/enioka/jqm/test/helpers/TestHelpers.java
+++ b/jqm-all/jqm-test-helpers/src/main/java/com/enioka/jqm/test/helpers/TestHelpers.java
@@ -47,7 +47,7 @@ public class TestHelpers
     public static void createTestData(DbConn cnx)
     {
         CreationTools.createJndiString(cnx, "string/debug", "a string which exists solely for test initialisation", "houba hop");
-        CreationTools.createDatabaseProp("jdbc/marsu", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdb", "SA", "", cnx,
+        CreationTools.createDatabaseProp("jdbc/marsu", "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:testdb", "SA", "SA", cnx,
                 "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS", null);
 
         GlobalParameter.create(cnx, "mavenRepo", "http://repo1.maven.org/maven2/");


### PR DESCRIPTION
As Mysql and MariaDB databases don't have sequence, add autoincrement for mysql and mariadb.

Update timestamp to millisecond precision
Avoid empty string for JNDI (mostly for oracle)
