### PR TITLE
Fixed wrong MIME/Media type for Long in web services

### DIFF
--- a/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/ClientApiTestJdbc.java
+++ b/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/integration/tests/ClientApiTestJdbc.java
@@ -555,7 +555,8 @@ public class ClientApiTestJdbc extends JqmBaseTest
 
         // Add an input file
         InputStream is = new ByteArrayInputStream(String.valueOf("Hello, World!").getBytes());
-        jqmClient.addJobFile(i, "SuperFile", is);
+        var id = jqmClient.addJobFile(i, "SuperFile", is);
+        Assert.assertTrue(id > 0);
 
         // Check file was created
         expectedFile.canRead();

--- a/jqm-all/jqm-ws/src/main/java/com/enioka/jqm/ws/api/ServiceClient.java
+++ b/jqm-all/jqm-ws/src/main/java/com/enioka/jqm/ws/api/ServiceClient.java
@@ -635,6 +635,7 @@ public class ServiceClient
     @Path("ji/{jobId}/files/{name}")
     @POST
     @Consumes("*/*")
+    @Produces({ "text/plain" })
     public long addJobFile(@PathParam("jobId") long jobId, @PathParam("name") String name, InputStream file)
     {
         if (jqmNodeId == null)


### PR DESCRIPTION
This was resulting in an error in some JAX-RS client implementations. Jersey is OK with receiving "application/json" and a single Long integer, but this is incorrect. And Jackson & CXF refuse this. So use the more usual "text/plain" instead.

This is not a breaking change: the API was not working with the previous media type.